### PR TITLE
Change links select box link fields to their associated section entries

### DIFF
--- a/lib/datasource-to-table.xsl
+++ b/lib/datasource-to-table.xsl
@@ -53,6 +53,11 @@
 		</xsl:attribute>
 		
 		<xsl:choose>
+			<xsl:when test="$field/item/@section-handle">
+				<a href="/symphony/publish/{$field/item/@section-handle}/edit/{$field/item/@id}/">
+					<xsl:value-of select="$field"/>
+				</a>
+			</xsl:when>
 			<xsl:when test="position()=1">
 				<a href="/symphony/publish/{//section/@handle}/edit/{$entry/@id}/">
 					<xsl:value-of select="$field"/>


### PR DESCRIPTION
I found I wanted this behavior as I'm constructing my internal CRM. The more I thought about it, it makes sense to link every select box link field to their associated section entry. It also makes the panel more dynamic.

The one caveat to how I implemented it gives precedence to the associated section entry for a select box link field even if it is the first column. I desire this behavior.

It might make sense to replace the when test with`$field/item/@section-handle and position() != 1`, which I think would be more universally accepted.

I leave it in your hands :-)
