### PR TITLE
fix error when Github is offline

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -482,7 +482,7 @@ Class Extension_Dashboard extends Extension{
 				$repo_tags = $ch->exec();
 				
 				// tags request found
-				if($repo_tags) {
+				if(is_array($repo_tags)) {
 					$repo_tags = json_decode($repo_tags);
 					$tags = array();
 


### PR DESCRIPTION
When Github is offline, `$repo_tags` arent null, because it have all 404 Gihtub html inside and return an error. Should be an array.